### PR TITLE
created an alias between sendemail and sendEmail

### DIFF
--- a/lib/ses.js
+++ b/lib/ses.js
@@ -60,6 +60,12 @@ SESClient.prototype.sendemail = function (options, callback) {
 }
 
 /**
+ * Alias sendEmail = sendemail
+ */
+
+SESClient.prototype.sendEmail = SESClient.prototype.sendemail;
+
+/**
  * Email constructor.
  *
  * @param {Object} options


### PR DESCRIPTION
In the DOCS and in the code comment blocks you mention the method client.sendEmail when the real method name is 'sendemail'. I think this alias should fix this now soy you can change the docs or keep the alias. 
