### PR TITLE
More flexible validation

### DIFF
--- a/lib/ses.js
+++ b/lib/ses.js
@@ -224,7 +224,7 @@ Email.prototype.signature = function () {
  */
 
 Email.prototype.validate = function () {
-  if (!this.to.length) return "To is required";
+  if (!this.to.length && !this.cc.length && !this.bcc.length) return "To, Cc or Bcc is required";
   if (!(this.from && this.from.length)) return "From is required";
   if (!(this.subject && this.subject.length)) return "Subject is required";
 }

--- a/test/index.js
+++ b/test/index.js
@@ -256,9 +256,20 @@ describe('Email', function(){
     it('should pass', function(){
       assert.equal(undefined, email.validate());
     })
-    it('should fail with To is required', function(){
+    it('should fail with To, Cc or Bcc is required', function(){
       email.to = [];
-      assert.equal("To is required", email.validate());
+      email.cc = [];
+      email.bcc = [];
+      assert.equal("To, Cc or Bcc is required", email.validate());
+
+      email.cc = ['works'];
+      assert.equal(undefined, email.validate());
+      email.cc = [];
+
+      email.bcc = ['works'];
+      assert.equal(undefined, email.validate());
+      email.bcc = [];
+
       email.to = ['works'];
       assert.equal(undefined, email.validate());
     })


### PR DESCRIPTION
SES doesn't need the `to` field, it needs at least one of `to` `cc` or `bcc`.
see http://docs.aws.amazon.com/ses/latest/APIReference/API_SendEmail.html 
and http://docs.aws.amazon.com/ses/latest/APIReference/API_Destination.html