### PR TITLE
Removing xml2json dependency for xml2js for smaller dependency footprint...

### DIFF
--- a/lib/ses.js
+++ b/lib/ses.js
@@ -5,7 +5,7 @@ var request = require('request')
   , parse = require('url').parse
   , querystring = require('querystring')
   , debug = require('debug')('node-ses')
-  , xmlParser = require('xml2json');
+  , xmlParser = require('xml2js');
 
 var Authorization = "AWS3-HTTPS AWSAccessKeyId={key}, Algorithm={algorithm}, Signature={Signature}";
 
@@ -279,7 +279,7 @@ function post (url, data, headers, callback) {
     if (err) return callback(err, data, res);
 
     if (res.statusCode < 200 || res.statusCode >= 400) {
-      var msg = xmlParser.toJson(data,  {object:true});
+      var msg = xmlParser.parseString(data);
       if(!msg.ErrorResponse){
         return callback("Unknown error: " + data);
       }

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -5,7 +5,8 @@ var request = require('request')
   , parse = require('url').parse
   , querystring = require('querystring')
   , debug = require('debug')('node-ses')
-  , xmlParser = require('xml2js');
+  , xmlParser = new require('xml2js').Parser({explicitArray:false,mergeAttrs:true});
+
 
 var Authorization = "AWS3-HTTPS AWSAccessKeyId={key}, Algorithm={algorithm}, Signature={Signature}";
 
@@ -279,13 +280,13 @@ function post (url, data, headers, callback) {
     if (err) return callback(err, data, res);
 
     if (res.statusCode < 200 || res.statusCode >= 400) {
-      var msg = xmlParser.parseString(data);
-      if(!msg.ErrorResponse){
-        return callback("Unknown error: " + data);
-      }
-      return callback(msg["ErrorResponse"]["Error"]);
+      xmlParser.parseString(data,function(err,result){
+          if(err)
+            return callback("Unknown error: "+err);
+          
+          callback(result.ErrorResponse.Error);
+      });
     }
-
     callback(null, data, res);
   });
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "debug": "0.5.0",
     "request": "2.9.153",
-    "xml2js": "*"
+    "xml2js": "0.4.*"
   },
   "devDependencies": {
     "mocha": "*"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "debug": "0.5.0",
     "request": "2.9.153",
-    "xml2json": "^0.5.1"
+    "xml2js": "*"
   },
   "devDependencies": {
     "mocha": "*"

--- a/test/index.js
+++ b/test/index.js
@@ -330,7 +330,8 @@ describe('Email', function(){
     it('should callback an error', function(done){
       email.send(function (err) {
         assert(err);
-        assert(/^node-ses failed with status: 403 and data:/.test(err.message));
+        assert(err.Message);
+        assert(/^The security token included in the request is invalid/.test(err.Message));
         done();
       });
     })


### PR DESCRIPTION
xml2json module builds lots of dependencie sand is huge.
Unless I missed something ( tests pass) it is not required and can do with this smaller footprint xml2js module.