### PR TITLE
Adding support for `sendRawEmail`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,27 @@
+{
+	"bitwise" : true,
+	"camelcase" : true,
+	"curly" : true,
+	"eqeqeq" : true,
+	"forin" : true,
+	"immed" : true,
+	"indent" : true,
+	"latedef" : true,
+	"laxcomma" : true,
+	"maxdepth" : 4,
+	"maxparams" : 6,
+	"newcap" : true,
+	"noarg" : true,
+	"noempty" : true,
+	"node" : true,
+	"nonew" : true,
+	"quotmark" : "single",
+	"strict" : true,
+	"trailing" : true,
+	"undef" : true,
+	"unused" : true,
+	"globals" : {
+		"describe" : true,
+		"it" : true
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+jshint:
+	@./node_modules/.bin/jshint lib/*.js test/*.js
 
 test:
 	@./node_modules/.bin/mocha --reporter list $(TESTFLAGS) $(TESTS)

--- a/lib/email.js
+++ b/lib/email.js
@@ -277,7 +277,7 @@ Email.prototype.validate = function () {
   }
 
   if (this.action === SEND_RAW_EMAIL_ACTION) {
-    if (!this.data) {
+    if (!(this.rawMessage && this.rawMessage.length)) {
       return 'Raw message is required';
     }
   }

--- a/lib/email.js
+++ b/lib/email.js
@@ -7,13 +7,15 @@ var crypto = require('crypto')
   , request = require('request')
   , xmlParser = new require('xml2js').Parser({explicitArray:false,mergeAttrs:true})
 
-  , DEFAULT_ACTION = 'SendEmail'
   , DEFAULT_AUTH_PATTERN = [
       'AWS3-HTTPS AWSAccessKeyId={key}'
     , 'Algorithm={algorithm}'
     , 'Signature={signature}'].join(', ')
   , DEFAULT_API_VERSION = '2010-12-01'
-  , DEFAULT_SIGNATURE_VERSION = 2;
+  , DEFAULT_SIGNATURE_VERSION = 2
+
+  , SEND_EMAIL_ACTION = 'SendEmail'
+  , SEND_RAW_EMAIL_ACTION = 'SendRawEmail';
 
 
 /**
@@ -75,7 +77,7 @@ function post (url, data, headers, callback) {
  * @param {Object} options
  **/
 function Email (options) {
-  this.action = options.action || DEFAULT_ACTION;
+  this.action = options.action || SEND_EMAIL_ACTION;
   this.key = options.key;
   this.secret = options.secret;
   this.algorithm = options.algorithm;
@@ -84,6 +86,7 @@ function Email (options) {
   this.subject = options.subject;
   this.message = options.message;
   this.altText = options.altText;
+  this.rawMessage = options.rawMessage;
   this.date = new Date(Date.now() + 10000).toUTCString();
   this.extractRecipient(options, 'to');
   this.extractRecipient(options, 'cc');
@@ -151,6 +154,7 @@ Email.prototype.addReplyTo = function (data) {
   this.replyTo.forEach(function(to, i) {
     data['ReplyToAddresses.member.' + (i + 1)] = to;
   });
+
   return data;
 };
 
@@ -172,9 +176,16 @@ Email.prototype.data = function () {
     , Source: this.from
   };
 
+  // recipients and reply tos
   data = this.addDestination(data);
-  data = this.addMessage(data);
   data = this.addReplyTo(data);
+
+  // message payload
+  if (this.action === SEND_EMAIL_ACTION) {
+    data = this.addMessage(data);
+  } else if (this.action === SEND_RAW_EMAIL_ACTION) {
+    data['RawMessage.Data'] = new Buffer(this.rawMessage).toString('base64');
+  }
 
   return data;
 };
@@ -255,20 +266,34 @@ Email.prototype.signature = function () {
  * @returns {String|Undefined}
  **/
 Email.prototype.validate = function () {
-  if (!this.to.length && !this.cc.length && !this.bcc.length) {
-    return 'To, Cc or Bcc is required';
+  if (this.action === SEND_EMAIL_ACTION) {
+    if (!this.to.length && !this.cc.length && !this.bcc.length) {
+      return 'To, Cc or Bcc is required';
+    }
+
+    if (!(this.subject && this.subject.length)) {
+      return 'Subject is required';
+    }
   }
 
+  if (this.action === SEND_RAW_EMAIL_ACTION) {
+    if (!this.data) {
+      return 'Raw message is required';
+    }
+  }
+
+  // all actions require the following
   if (!(this.from && this.from.length)) {
     return 'From is required';
-  }
-
-  if (!(this.subject && this.subject.length)) {
-    return 'Subject is required';
   }
 };
 
 /**
  * Exports
  **/
-module.exports = Email;
+exports.Email = Email;
+
+exports.actions = {
+  SendEmail : SEND_EMAIL_ACTION,
+  SendRawEmail : SEND_RAW_EMAIL_ACTION
+};

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,0 +1,274 @@
+'use strict';
+
+var crypto = require('crypto')
+  , debug = require('debug')('node-ses')
+  , parse = require('url').parse
+  , querystring = require('querystring')
+  , request = require('request')
+  , xmlParser = new require('xml2js').Parser({explicitArray:false,mergeAttrs:true})
+
+  , DEFAULT_ACTION = 'SendEmail'
+  , DEFAULT_AUTH_PATTERN = [
+      'AWS3-HTTPS AWSAccessKeyId={key}'
+    , 'Algorithm={algorithm}'
+    , 'Signature={signature}'].join(', ')
+  , DEFAULT_API_VERSION = '2010-12-01'
+  , DEFAULT_SIGNATURE_VERSION = 2;
+
+
+/**
+ * Sends a request to the AWS service.
+ * @private
+ *
+ * @param {String} url
+ * @param {Object} data
+ * @param {Object} headers
+ * @param {Function} callback
+ *
+ * TODO: support more than sendmail
+ **/
+// jshint sub : true
+function post (url, data, headers, callback) {
+  data = querystring.stringify(data);
+
+  var parsedUrl = parse(url);
+
+  headers.Host = parsedUrl.hostname;
+  headers['Content-Type'] = 'application/x-www-form-urlencoded';
+  headers['Content-Length'] = data.length;
+  headers['Connection'] = 'Keep-Alive';
+
+  var options = {
+      url: url
+    , headers: headers
+    , encoding: 'utf8'
+    , body: data
+    , method: 'POST'
+  };
+
+  debug('posting: %j', data);
+
+  request(options, function (err, res, data) {
+    debug('received: %s %d %j', err, res && res.statusCode || 0, data);
+
+    if (err) {
+      return callback(err, data, res);
+    }
+
+    if (res.statusCode < 200 || res.statusCode >= 400) {
+      return xmlParser.parseString(data,function(err,result){
+          if(err) {
+            return callback('Unknown error: ' + err);
+          }
+
+          return callback(result.ErrorResponse.Error);
+      });
+    }
+    return callback(null, data, res);
+  });
+}
+
+
+/**
+ * Email constructor.
+ *
+ * @param {Object} options
+ **/
+function Email (options) {
+  this.action = options.action || DEFAULT_ACTION;
+  this.key = options.key;
+  this.secret = options.secret;
+  this.algorithm = options.algorithm;
+  this.amazon = options.amazon;
+  this.from = options.from;
+  this.subject = options.subject;
+  this.message = options.message;
+  this.altText = options.altText;
+  this.date = new Date(Date.now() + 10000).toUTCString();
+  this.extractRecipient(options, 'to');
+  this.extractRecipient(options, 'cc');
+  this.extractRecipient(options, 'bcc');
+  this.extractRecipient(options, 'replyTo');
+}
+
+
+/**
+ * Adds to, cc, and bcc fields to `data`.
+ *
+ * @param {Object} data
+ * @return data
+ **/
+Email.prototype.addDestination = function (data) {
+  this.to.forEach(function (to, i) {
+    data['Destination.ToAddresses.member.' + (i + 1)] = to;
+  });
+
+  this.cc.forEach(function (to, i) {
+    data['Destination.CcAddresses.member.' + (i + 1)] = to;
+  });
+
+  this.bcc.forEach(function (to, i) {
+    data['Destination.BccAddresses.member.' + (i + 1)] = to;
+  });
+
+  return data;
+};
+
+
+/**
+ * Adds subject, alt text, and message body to `data`.
+ *
+ * @param {Object} data
+ * @return data
+ **/
+Email.prototype.addMessage = function (data) {
+  if (this.subject) {
+    data['Message.Subject.Data'] = this.subject;
+    data['Message.Subject.Charset'] = 'UTF-8';
+  }
+
+  if (this.message) {
+    data['Message.Body.Html.Data'] = this.message;
+    data['Message.Body.Html.Charset'] = 'UTF-8';
+  }
+
+  if (this.altText) {
+    data['Message.Body.Text.Data'] = this.altText;
+    data['Message.Body.Text.Charset'] = 'UTF-8';
+  }
+
+  return data;
+};
+
+
+/**
+ * Adds the list of ReplyTos to `data`.
+ *
+ * @param {Object} data
+ * @return data
+ **/
+Email.prototype.addReplyTo = function (data) {
+  this.replyTo.forEach(function(to, i) {
+    data['ReplyToAddresses.member.' + (i + 1)] = to;
+  });
+  return data;
+};
+
+
+/**
+ * Prepares param object for the AWS request.
+ *
+ * @return {Object}
+ */
+Email.prototype.data = function () {
+  var data = {
+      Action: this.action
+    , AWSAccessKeyId: this.key
+    , Signature: this.signature
+    , SignatureMethod: 'Hmac' + this.algorithm
+    , SignatureVersion: DEFAULT_SIGNATURE_VERSION
+    , Version: DEFAULT_API_VERSION
+    , Expires: this.date
+    , Source: this.from
+  };
+
+  data = this.addDestination(data);
+  data = this.addMessage(data);
+  data = this.addReplyTo(data);
+
+  return data;
+};
+
+
+/**
+ * Extracts recipients from options.
+ *
+ * @param {String} prop - either to,cc,bcc,replyTo
+ * @param {Object} options
+ */
+Email.prototype.extractRecipient = function (options, prop) {
+  if (options[prop]) {
+    this[prop] = Array.isArray(options[prop]) ? options[prop] : [options[prop]];
+  } else {
+    this[prop] = [];
+  }
+};
+
+
+/**
+ * Creates required AWS headers.
+ *
+ * @return Object
+ **/
+Email.prototype.headers = function () {
+  var headers = {};
+
+  headers.Date = this.date;
+  headers['X-Amzn-Authorization'] = DEFAULT_AUTH_PATTERN
+    .replace('{key}', this.key)
+    .replace('{algorithm}', 'Hmac' + this.algorithm)
+    .replace('{signature}', this.signature());
+
+	return headers;
+};
+
+
+/**
+ * Sends the email.
+ *
+ * @param {Function} callback
+ * @api Public
+ **/
+Email.prototype.send = function send (callback) {
+  var invalid = this.validate();
+
+  if (invalid) {
+    return callback(new Error(invalid));
+  }
+
+  return post(this.amazon, this.data(), this.headers(), callback);
+};
+
+
+/**
+ * Creates the Amazon signature for the request.
+ *
+ * @return base64 encoded string
+ **/
+Email.prototype.signature = function () {
+  if (this._signature) {
+    return this._signature;
+  }
+
+  this._signature = crypto
+    .createHmac(this.algorithm.toLowerCase(), this.secret)
+    .update(this.date)
+    .digest('base64');
+
+  return this._signature;
+};
+
+
+/**
+ * Validates the input.
+ *
+ * @returns {String|Undefined}
+ **/
+Email.prototype.validate = function () {
+  if (!this.to.length && !this.cc.length && !this.bcc.length) {
+    return 'To, Cc or Bcc is required';
+  }
+
+  if (!(this.from && this.from.length)) {
+    return 'From is required';
+  }
+
+  if (!(this.subject && this.subject.length)) {
+    return 'Subject is required';
+  }
+};
+
+/**
+ * Exports
+ **/
+module.exports = Email;

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -1,14 +1,23 @@
 // node-ses
+'use strict';
 
-var request = require('request')
-  , crypto = require('crypto')
-  , parse = require('url').parse
-  , querystring = require('querystring')
-  , debug = require('debug')('node-ses')
-  , xmlParser = new require('xml2js').Parser({explicitArray:false,mergeAttrs:true});
+var Email = require('./email')
+
+  , DEFAULT_API_HOST = 'https://email.us-east-1.amazonaws.com'
+  , DEFAULT_SIGNATURE_ALGORITHM = 'SHA1';
 
 
-var Authorization = "AWS3-HTTPS AWSAccessKeyId={key}, Algorithm={algorithm}, Signature={Signature}";
+/**
+ * Options helper.
+ * @private
+ */
+function expect (options, key) {
+  if (options && options[key]) {
+    return options[key];
+  }
+
+  throw new Error(key + ' is required');
+}
 
 /**
  * SESClient
@@ -37,7 +46,6 @@ var Authorization = "AWS3-HTTPS AWSAccessKeyId={key}, Algorithm={algorithm}, Sig
  *
  * @param {Object} options
  */
-
 function SESClient (options) {
   this.key = expect(options, 'key');
   this.secret = expect(options, 'secret');
@@ -45,271 +53,31 @@ function SESClient (options) {
   this.amazon = options.amazon || exports.amazon;
 }
 
+
 /**
  * Send an email
  *
  * @param {Object} options
  * @param {Function} callback
  */
-
 SESClient.prototype.sendemail = function (options, callback) {
   options.key = options.key = this.key;
   options.secret = options.secret || this.secret;
   options.algorithm = options.algorithm || this.algorithm;
   options.amazon = options.amazon || this.amazon;
+
   var email = new Email(options);
   email.send(callback);
-}
+};
 
 /**
- * Email constructor.
- *
- * @param {Object} options
- */
-
-function Email (options) {
-  this.key = options.key;
-  this.secret = options.secret;
-  this.algorithm = options.algorithm;
-  this.amazon = options.amazon;
-  this.from = options.from;
-  this.subject = options.subject;
-  this.message = options.message;
-  this.altText = options.altText;
-  this.date = new Date(Date.now() + 10000).toUTCString();
-  this.extractRecipient(options, 'to');
-  this.extractRecipient(options, 'cc');
-  this.extractRecipient(options, 'bcc');
-  this.extractRecipient(options, 'replyTo');
-}
-
-/**
- * Extracts recipients from options.
- *
- * @param {String} prop - either to,cc,bcc,replyTo
- * @param {Object} options
- */
-
-Email.prototype.extractRecipient = function (options, prop) {
-  if (options[prop]) {
-    this[prop] = Array.isArray(options[prop])
-      ? options[prop]
-      : [options[prop]]
-  } else {
-    this[prop] = [];
-  }
-}
-
-/**
- * Prepares param object for the AWS request.
- *
- * @return {Object}
- */
-
-Email.prototype.data = function () {
-  var data = {
-      Action: "SendEmail"
-    , AWSAccessKeyId: this.key
-    , Signature: this.signature
-    , SignatureMethod: 'Hmac' + this.algorithm
-    , SignatureVersion: 2
-    , Version: "2010-12-01"
-    , Expires: this.date
-    , Source: this.from
-  }
-
-  data = this.addDestination(data);
-  data = this.addMessage(data);
-  data = this.addReplyTo(data);
-
-  return data;
-}
-
-/**
- * Adds subject, alt text, and message body to `data`.
- *
- * @param {Object} data
- * @return data
- */
-
-Email.prototype.addMessage = function (data) {
-  if (this.subject) {
-    data["Message.Subject.Data"] = this.subject;
-    data["Message.Subject.Charset"] = 'UTF-8';
-  }
-
-  if (this.message) {
-    data["Message.Body.Html.Data"] = this.message;
-    data["Message.Body.Html.Charset"] = 'UTF-8';
-  }
-
-  if (this.altText) {
-    data["Message.Body.Text.Data"] = this.altText;
-    data["Message.Body.Text.Charset"] = 'UTF-8';
-  }
-
-  return data;
-}
-
-/**
- * Adds to, cc, and bcc fields to `data`.
- *
- * @param {Object} data
- * @return data
- */
-
-Email.prototype.addDestination = function (data) {
-  this.to.forEach(function (to, i) {
-    data["Destination.ToAddresses.member." + (i + 1)] = to;
-  });
-
-  this.cc.forEach(function (to, i) {
-    data["Destination.CcAddresses.member." + (i + 1)] = to;
-  });
-
-  this.bcc.forEach(function (to, i) {
-    data["Destination.BccAddresses.member." + (i + 1)] = to;
-  });
-
-  return data;
-}
-
-/**
- * Adds the list of ReplyTos to `data`.
- *
- * @param {Object} data
- * @return data
- */
-
-Email.prototype.addReplyTo = function (data) {
-  this.replyTo.forEach(function(to, i) {
-    data["ReplyToAddresses.member." + (i + 1)] = to;
-  });
-  return data;
-}
-
-/**
- * Creates required AWS headers.
- *
- * @return Object
- */
-
-Email.prototype.headers = function () {
-  var headers = {};
-  headers.Date = this.date;
-  headers['X-Amzn-Authorization'] =
-    Authorization.replace("{key}", this.key)
-                 .replace("{algorithm}", 'Hmac' + this.algorithm)
-                 .replace("{Signature}", this.signature());
-  return headers;
-}
-
-/**
- * Creates the Amazon signature for the request.
- *
- * @return base64 encoded string
- */
-
-Email.prototype.signature = function () {
-  if (this._signature) return this._signature;
-  var sig = crypto.createHmac(this.algorithm.toLowerCase(), this.secret)
-                  .update(this.date)
-                  .digest('base64');
-  return this._signature = sig;
-}
-
-/**
- * Validates the input.
- *
- * @returns {String|Undefined}
- */
-
-Email.prototype.validate = function () {
-  if (!this.to.length && !this.cc.length && !this.bcc.length) return "To, Cc or Bcc is required";
-  if (!(this.from && this.from.length)) return "From is required";
-  if (!(this.subject && this.subject.length)) return "Subject is required";
-}
-
-/**
- * Sends the email.
- *
- * @param {Function} callback
- * @api Public
- */
-
-Email.prototype.send = function send (callback) {
-  var invalid = this.validate();
-  if (invalid) return callback(new Error(invalid));
-  post(this.amazon, this.data(), this.headers(), callback);
-}
-
-/**
- * Sends a request to the AWS service.
- *
- * @param {String} url
- * @param {Object} data
- * @param {Object} headers
- * @param {Function} callback
- *
- * TODO: support more than sendmail
- */
-
-function post (url, data, headers, callback) {
-  data = querystring.stringify(data);
-
-  var parsedUrl = parse(url);
-
-  headers.Host = parsedUrl.hostname;
-  headers['Content-Type'] = 'application/x-www-form-urlencoded';
-  headers['Content-Length'] = data.length;
-  headers['Connection'] = 'Keep-Alive';
-
-  var options = {
-      url: url
-    , headers: headers
-    , encoding: 'utf8'
-    , body: data
-    , method: 'POST'
-  };
-
-  debug('posting: %j', data);
-
-  request(options, function (err, res, data) {
-    debug('received: %s %d %j', err, res && res.statusCode || 0, data);
-
-    if (err) return callback(err, data, res);
-
-    if (res.statusCode < 200 || res.statusCode >= 400) {
-      return xmlParser.parseString(data,function(err,result){
-          if(err)
-            return callback("Unknown error: "+err);
-
-          return callback(result.ErrorResponse.Error);
-      });
-    }
-    return callback(null, data, res);
-  });
-}
-
-/**
- * Options helper.
- * @private
- */
-
-function expect (options, key) {
-  if (options && options[key]) return options[key];
-  throw new Error(key + ' is required');
-}
-
-/**
- * Expose.
- */
-
+ * Exports
+ **/
 exports.createClient = function createClien (options) {
   return new SESClient(options);
-}
+};
 
 exports.Email = Email;
-exports.amazon = 'https://email.us-east-1.amazonaws.com';
-exports.algorithm = 'SHA1';
+exports.amazon = DEFAULT_API_HOST;
+exports.algorithm = DEFAULT_SIGNATURE_ALGORITHM;
 exports.version = require('../package').version;

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -1,7 +1,7 @@
 // node-ses
 'use strict';
 
-var Email = require('./email')
+var email = require('./email')
 
   , DEFAULT_API_HOST = 'https://email.us-east-1.amazonaws.com'
   , DEFAULT_SIGNATURE_ALGORITHM = 'SHA1';
@@ -60,14 +60,40 @@ function SESClient (options) {
  * @param {Object} options
  * @param {Function} callback
  */
-SESClient.prototype.sendemail = function (options, callback) {
+SESClient.prototype.sendEmail = function (options, callback) {
   options.key = options.key = this.key;
   options.secret = options.secret || this.secret;
   options.algorithm = options.algorithm || this.algorithm;
   options.amazon = options.amazon || this.amazon;
+  options.action = email.actions.SendEmail;
 
-  var email = new Email(options);
-  email.send(callback);
+  var message = new email.Email(options);
+  message.send(callback);
+};
+
+/**
+ * Send an email (convenience alias to sendemail)
+ *
+ * @param {Object} options
+ * @param {Function} callback
+ **/
+SESClient.prototype.sendemail = SESClient.prototype.sendemail;
+
+/**
+ * Send an email (raw)
+ *
+ * @param {Object} options
+ * @param {Function} callback
+ */
+SESClient.prototype.sendRawEmail = function (options, callback) {
+  options.key = options.key || this.key;
+  options.secret = options.secret || this.secret;
+  options.algorithm = options.algorithm || this.algorithm;
+  options.amazon = options.amazon || this.amazon;
+  options.action = email.actions.SendRawEmail;
+
+  var message = new email.Email(options);
+  message.send(callback);
 };
 
 /**
@@ -77,7 +103,7 @@ exports.createClient = function createClien (options) {
   return new SESClient(options);
 };
 
-exports.Email = Email;
+exports.Email = email.Email;
 exports.amazon = DEFAULT_API_HOST;
 exports.algorithm = DEFAULT_SIGNATURE_ALGORITHM;
 exports.version = require('../package').version;

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -77,7 +77,7 @@ SESClient.prototype.sendEmail = function (options, callback) {
  * @param {Object} options
  * @param {Function} callback
  **/
-SESClient.prototype.sendemail = SESClient.prototype.sendemail;
+SESClient.prototype.sendemail = SESClient.prototype.sendEmail;
 
 /**
  * Send an email (raw)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
-  "contributors" : [
+  "contributors": [
     "Mark Stosberg <mark@rideamigos.com> http://mark.stosberg.com"
   ],
-  "license" : "MIT",
+  "license": "MIT",
   "description": "Amazon SES (sendmail) for node",
   "keywords": [
     "amazon",
@@ -26,6 +26,7 @@
     "xml2js": "0.4.*"
   },
   "devDependencies": {
+    "jshint": "^2.8.0",
     "mocha": "*"
   },
   "optionalDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
   "contributors": [
-    "Mark Stosberg <mark@rideamigos.com> http://mark.stosberg.com"
+    "Mark Stosberg <mark@rideamigos.com> http://mark.stosberg.com",
+    "Joshua Thomas <joshua.thomas+github@gmail.com> http://github.com/brozeph"
   ],
   "license": "MIT",
   "description": "Amazon SES (sendmail) for node",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "amazon-ses"
   ],
   "name": "node-ses",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/aheckmann/node-ses.git"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,12 @@
+'use strict';
 
 // use mocha for test
 
 var assert = require('assert')
   , ses = require('../')
-  , crypto = require('crypto')
+  , crypto = require('crypto');
 
-function create () {
+function create (){
   return new ses.Email({
       key: 'key'
     , secret: 'secret'
@@ -22,43 +23,52 @@ function create () {
 }
 
 describe('node-ses', function(){
-  it('should have createClient and Email exports', function () {
+  it('should have createClient and Email exports', function (){
     assert.equal('function', typeof ses.createClient);
     assert.equal('function', typeof ses.Email);
   });
+
   it('should have a version', function(){
     assert(ses.version);
-  })
-})
+  });
+});
 
 describe('createClient', function(){
   var client = ses.createClient({
       key: 'mykey'
     , secret: 'mysecret'
   });
+
   it('should have a key', function(){
     assert.ok(client.key);
   });
+
   it('should have a secret', function(){
     assert.ok(client.secret);
   });
+
   it('should have an algorithm', function(){
     assert.ok(client.algorithm);
   });
+
   it('algorithm should default to SHA1', function(){
     assert.equal(client.algorithm, 'SHA1');
   });
+
   it('algorithm should be overiddable', function(){
     var client = ses.createClient({ algorithm: 'different', key: 1, secret: 2 });
     assert.equal(client.algorithm, 'different');
   });
+
   it('should have an amazon property', function(){
     assert.ok(client.amazon);
   });
+
   it('amazon should default correctly', function(){
     var amazon = 'https://email.us-east-1.amazonaws.com';
     assert.equal(client.amazon, amazon);
   });
+
   it('amazon should be overiddable', function(){
     var client = ses.createClient({
         amazon: 'http://www.google.com'
@@ -67,26 +77,33 @@ describe('createClient', function(){
     });
     assert.equal(client.amazon, 'http://www.google.com');
   });
+
   it('should require a key', function(){
     try {
-      ses.createClient()
+      ses.createClient();
     } catch (err) {
-      if (!/key is required/.test(err)) throw err;
+      if (!/key is required/.test(err)) {
+        throw err;
+      }
     }
   });
+
   it('should require a secret', function(){
     try {
-      ses.createClient({ key: 1 })
+      ses.createClient({ key: 1 });
     } catch (err) {
-      if (!/secret is required/.test(err)) throw err;
+      if (!/secret is required/.test(err)) {
+        throw err;
+      }
     }
   });
+
   describe('sendemail', function(){
     it('should be a function', function(){
-      assert.equal('function', typeof client.sendemail)
-    })
-  })
-})
+      assert.equal('function', typeof client.sendemail);
+    });
+  });
+});
 
 describe('Email', function(){
   var email = new ses.Email({
@@ -105,52 +122,60 @@ describe('Email', function(){
 
   it('should have key', function(){
     assert.equal('key', email.key);
-  })
+  });
+
   it('should have secret', function(){
     assert.equal('secret', email.secret);
-  })
+  });
+
   it('should have algorithm', function(){
     assert.equal('algo', email.algorithm);
-  })
+  });
+
   it('should have from', function(){
     assert.equal('from', email.from);
-  })
+  });
+
   it('should have subject', function(){
     assert.equal('subject', email.subject);
-  })
+  });
+
   it('should have message', function(){
     assert.equal('message', email.message);
-  })
+  });
+
   it('should have altText', function(){
     assert.equal('alt', email.altText);
-  })
+  });
 
   describe('#extractRecipient', function(){
     it('should default to an array', function(){
       email.extractRecipient({ to: 'hi' }, 'from');
       assert(Array.isArray(email.from));
       assert.equal(0, email.from.length);
-    })
+    });
+
     it('should convert to an array', function (){
       email.extractRecipient({ to: 'hi' }, 'to');
       assert(Array.isArray(email.from));
       assert.equal(1, email.to.length);
       assert.equal('hi', email.to[0]);
-    })
+    });
+
     it('should leave arrays untouched', function(){
       email.extractRecipient({ yep: ['hi'] }, 'yep');
       assert(Array.isArray(email.yep));
       assert.equal(1, email.yep.length);
       assert.equal('hi', email.yep[0]);
-    })
-  })
+    });
+  });
 
   describe('#addMessage', function(){
     var email = create();
 
     it('should be a function', function(){
       assert.equal('function', typeof email.addMessage);
-    })
+    });
 
     it('should add subject,message,altText', function(){
       var msg = email.addMessage({});
@@ -167,14 +192,14 @@ describe('Email', function(){
       assert.equal(msg['Message.Body.Html.Charset'], 'UTF-8');
       assert.equal(msg['Message.Body.Text.Data'], 'alt');
       assert.equal(msg['Message.Body.Text.Charset'], 'UTF-8');
-    })
-  })
+    });
+  });
 
   describe('#addDestination', function(){
     var email = create();
     it('should be a function', function(){
       assert.equal('function', typeof email.addDestination);
-    })
+    });
 
     it('should add Destination data', function(){
       var msg = email.addDestination({});
@@ -189,54 +214,54 @@ describe('Email', function(){
       assert.equal(msg['Destination.CcAddresses.member.1'], 'cc@example.com');
       assert.equal(msg['Destination.BccAddresses.member.1'], 'bcc@example.com');
       assert.equal(msg['Destination.BccAddresses.member.2'], 'yoyo@example.com');
-    })
-
-
-
-  })
+    });
+  });
 
   describe('#addReplyTo', function(){
     var email = create();
+
     it('should be a function', function(){
       assert.equal('function', typeof email.addReplyTo);
-    })
+    });
+
     it('should add replyTo data', function(){
       var msg = email.addReplyTo({});
       assert(msg['ReplyToAddresses.member.1']);
       assert.equal(msg['ReplyToAddresses.member.1'], 'bcc@example.com');
-    })
-  })
+    });
+  });
 
   describe('#signature', function(){
     var email = create();
-    email.algorithm = 'SHA1'
+    email.algorithm = 'SHA1';
 
-    var sig = crypto.createHmac(email.algorithm.toLowerCase(), email.secret)
-                .update(email.date)
-                .digest('base64');
+    var sig = crypto
+      .createHmac(email.algorithm.toLowerCase(), email.secret)
+      .update(email.date)
+      .digest('base64');
 
     it('should be a function', function(){
       assert.equal('function', typeof email.signature);
-    })
+    });
 
     it('should compute the base64 hmac', function(){
       assert.equal(sig, email.signature());
-    })
+    });
 
     it('should return the same value if called > 1', function(){
       assert.equal(sig, email.signature());
       assert.equal(sig, email.signature());
       assert.equal(email._signature, email.signature());
-    })
-  })
+    });
+  });
 
   describe('#headers', function(){
     var email = create();
-    email.algorithm = 'SHA1'
+    email.algorithm = 'SHA1';
 
     it('should be a function', function(){
       assert.equal('function', typeof email.headers);
-    })
+    });
 
     it('should add headers', function(){
       var h = email.headers({});
@@ -245,22 +270,25 @@ describe('Email', function(){
       assert(/AWSAccessKeyId=/.test(h['X-Amzn-Authorization']));
       assert(/Algorithm=/.test(h['X-Amzn-Authorization']));
       assert(/Signature=/.test(h['X-Amzn-Authorization']));
-    })
-  })
+    });
+  });
 
   describe('#validate', function(){
     var email = create();
+
     it('should be a function', function(){
       assert.equal('function', typeof email.validate);
-    })
+    });
+
     it('should pass', function(){
       assert.equal(undefined, email.validate());
-    })
+    });
+
     it('should fail with To, Cc or Bcc is required', function(){
       email.to = [];
       email.cc = [];
       email.bcc = [];
-      assert.equal("To, Cc or Bcc is required", email.validate());
+      assert.equal('To, Cc or Bcc is required', email.validate());
 
       email.cc = ['works'];
       assert.equal(undefined, email.validate());
@@ -272,38 +300,42 @@ describe('Email', function(){
 
       email.to = ['works'];
       assert.equal(undefined, email.validate());
-    })
+    });
+
     it('should fail with From is required', function(){
       delete email.from;
-      assert.equal("From is required", email.validate());
+      assert.equal('From is required', email.validate());
       email.from = null;
-      assert.equal("From is required", email.validate());
+      assert.equal('From is required', email.validate());
       email.from = '';
-      assert.equal("From is required", email.validate());
+      assert.equal('From is required', email.validate());
       email.from = 'yup@asdf.com';
       assert.equal(undefined, email.validate());
-    })
+    });
+
     it('should fail with Subject is required', function(){
       delete email.subject;
-      assert.equal("Subject is required", email.validate());
+      assert.equal('Subject is required', email.validate());
       email.subject = null;
-      assert.equal("Subject is required", email.validate());
+      assert.equal('Subject is required', email.validate());
       email.subject = '';
-      assert.equal("Subject is required", email.validate());
+      assert.equal('Subject is required', email.validate());
       email.subject = 'spammer';
       assert.equal(undefined, email.validate());
-    })
-  })
+    });
+  });
 
   describe('#data', function(){
     var email = create();
+
     it('should be a function', function(){
       assert.equal('function', typeof email.data);
-    })
+    });
+
     it('should contain the formatted emails data', function(){
       var d = email.data({});
-      assert(d.Action)
-      assert.equal(d.Action, 'SendEmail')
+      assert(d.Action);
+      assert.equal(d.Action, 'SendEmail');
       assert(d.AWSAccessKeyId);
       assert.equal(email.key, d.AWSAccessKeyId);
       assert(d.Signature);
@@ -328,29 +360,32 @@ describe('Email', function(){
       assert(d['Message.Body.Text.Data']);
       assert(d['Message.Body.Text.Charset']);
       assert(d['ReplyToAddresses.member.1']);
-    })
-  })
+    });
+  });
 
   describe('#send', function(){
     var email = create();
-    email.algorithm = 'SHA1'
+
+    email.algorithm = 'SHA1';
     email.amazon = ses.amazon;
+
     it('should be a function', function(){
       assert.equal('function', typeof email.send);
-    })
+    });
+
     it('should callback an error', function(done){
       this.timeout(5000);
       var calledTimes = 0;
       email.send(function (err) {
         calledTimes++;
-        assert.equal(calledTimes,1,"callback was called only once");
+        assert.equal(calledTimes,1,'callback was called only once');
         assert(err);
         assert(err.Message);
         assert(/^The security token included in the request is invalid/.test(err.Message));
         // Wait to see if the code is accidentally going to run the test before declaring done.
         setTimeout(done,1000);
       });
-    })
+    });
 
     if (process.env.NODE_SES_KEY && process.env.NODE_SES_SECRET) {
       it('should succeed', function(done){
@@ -358,6 +393,7 @@ describe('Email', function(){
             key: process.env.NODE_SES_KEY
           , secret: process.env.NODE_SES_SECRET
         });
+
         client.sendemail({
             from: 'noreply@learnboost.com'
           , subject: 'testing node-ses'
@@ -372,9 +408,9 @@ describe('Email', function(){
           assert(data);
           done();
         });
-      })
+      });
     } else {
       console.error('You are not testing with Amazons SES service');
     }
-  })
-})
+  });
+});


### PR DESCRIPTION
To address issue #5 (my own needs required this as well), I implemented the sendRawEmail capability in this excellent module. Additionally, I've added unit tests and upp'd the minor version (set to `v1.1.0`) in the `package.json` file.

A couple other minor adjustments made (note, these are highly opinionated on my part; I completely respect if you wish to deny the PR as a result of any of these):
* added `make jshint` task 
* adjusted code slightly to address all `jshint` warnings 
* added documentation for `sendRawEmail` method to the `README.md`
* aliased `client.sendemail` to `client.sendEmail` for case consistency
* split the `Email` object to its own file (in `lib/email.js`) for easier maintenance