### PR TITLE
Refactor internals to support AWS authentication version 4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,29 @@
 
+2.0.0 / 2016-08-12
+==================
+
+There's a major version bump because the internals changed signficantly as part
+of switching to version 4 authentication signatures with AWS. The upgrade
+is backwards compatible with 1.2 for normal use.
+
+
+[NEW FEATURES]
+
+ * Add webpack compatibility (cspeer)
+
+[INTERNALS]
+
+ * Switched from using "version 2" AWS authentication signatures to "version 4" for future proofing. (markstos)
+ * Processing the response from AWS has been moved to it's own function, paving the way for future testing, and
+   overriding this part of the module. For now the function remains undocumented. (markstos)
+
+[BREAKING CHANGES]
+
+ * 'algorithm' property is no longer exported and the option to change it is removed. If you are using an alternate algorithm to sign version 4 Authentication signatures, a pull request is welcome to restore this feature.
+
+
 1.2.0 / 2016-04-07
+==================
 
 [DOCUMENTATION]
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,18 @@ See the [debug module](https://www.npmjs.org/package/debug) docs for more debug 
 
 ## Running the Tests
 
+Unit tests
+
  `npm test`
+
+To run the full tests, including actually using the AWS SES REST APIs with your credentials, set the following environment variables:
+
+    # Your SES Key and secret
+    NODE_SES_KEY
+    NODE_SES_SECRET
+
+    # An email that is both an verified sende that can also receive test emails. Possibly your own email address
+    NODE_SES_EMAIL
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ You'll probably only be using this method. It takes an options object with the f
 
     `key` - (required) your AWS SES key
     `secret` - (required) your AWS SES secret
-    `algorithm` - [optional] the AWS algorithm you are using. defaults to SHA1.
     `amazon` - [optional] the amazon end-point uri. defaults to `https://email.us-east-1.amazonaws.com`
 
 Not all AWS regions support SES. Check [SES region support](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html) to be sure the region you are in is supported.
@@ -95,8 +94,7 @@ Optional properties (overrides the values set in `createClient`):
 
     `key` - AWS key
     `secret` - AWS secret
-    `algorithm` - AWS algorithm to use
-    `amazon` - AWS end point
+    `amazon` - AWS end point. Defaults to `https://email.us-east-1.amazonaws.com`
 
 The `sendEmail` method transports your message to the AWS SES service. If Amazon
 returns an HTTP status code that's less than `200` or greater than or equal to
@@ -245,7 +243,7 @@ See the [debug module](https://www.npmjs.org/package/debug) docs for more debug 
 
 ## Running the Tests
 
-`make test`
+ `npm test`
 
 ## See Also
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var crypto = require('crypto')
+var aws4 = require('aws4')
   , debug = require('debug')('node-ses')
   , parse = require('url').parse
   , querystring = require('querystring')
@@ -8,78 +8,10 @@ var crypto = require('crypto')
   , xml2js = require('xml2js')
   , xmlParser = new xml2js.Parser({explicitArray:false,mergeAttrs:true})
 
-  // Declare constants for details of AWS SES API that we depend on.
-  , DEFAULT_AUTH_PATTERN = [
-      'AWS3-HTTPS AWSAccessKeyId={key}'
-    , 'Algorithm={algorithm}'
-    , 'Signature={signature}'].join(', ')
-  , DEFAULT_API_VERSION = '2010-12-01'
-  , DEFAULT_SIGNATURE_VERSION = 2
-
   , SEND_EMAIL_ACTION = 'SendEmail'
   , SEND_RAW_EMAIL_ACTION = 'SendRawEmail';
 
-/**
- * Sends a request to the AWS service.
- * @private
- *
- * @param {String} url
- * @param {Object} data
- * @param {Object} headers
- * @param {Function} callback
- *
- * TODO: support more than sendmail
- **/
-// jshint sub : true
-function post (url, data, headers, callback) {
-  data = querystring.stringify(data);
 
-  var parsedUrl = parse(url);
-
-  headers.Host = parsedUrl.hostname;
-  headers['Content-Type'] = 'application/x-www-form-urlencoded';
-  headers['Content-Length'] = data.length;
-  headers['Connection'] = 'Keep-Alive';
-
-  var options = {
-      url: url
-    , headers: headers
-    , encoding: 'utf8'
-    , body: data
-    , method: 'POST'
-  };
-
-  debug('posting: %j', data);
-
-  request(options, function (err, res, data) {
-    debug('received: %s %d %j', err, res && res.statusCode || 0, data);
-
-    if (err) {
-      return callback({
-        Type : "NodeSesInternal",
-        Code : "RequestError",
-        Message: err,
-      }, data, res);
-    }
-
-    if (res.statusCode < 200 || res.statusCode >= 400) {
-      return xmlParser.parseString(data,function(err,result){
-          if(err) {
-            return callback({
-              Type: "NodeSesInternal",
-              Code: "ParseError",
-              Message: err
-            });
-          }
-
-          // Return an error object with keys of Type, Code and Message
-          // Rference docs at: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/query-interface-responses.html
-          return callback(result.ErrorResponse.Error);
-      });
-    }
-    return callback(null, data, res);
-  });
-}
 
 
 /**
@@ -91,14 +23,12 @@ function Email (options) {
   this.action = options.action || SEND_EMAIL_ACTION;
   this.key = options.key;
   this.secret = options.secret;
-  this.algorithm = options.algorithm;
   this.amazon = options.amazon;
   this.from = options.from;
   this.subject = options.subject;
   this.message = options.message;
   this.altText = options.altText;
   this.rawMessage = options.rawMessage;
-  this.date = new Date(Date.now() + 10000).toUTCString();
   this.extractRecipient(options, 'to');
   this.extractRecipient(options, 'cc');
   this.extractRecipient(options, 'bcc');
@@ -179,11 +109,6 @@ Email.prototype.data = function () {
   var data = {
       Action: this.action
     , AWSAccessKeyId: this.key
-    , Signature: this.signature
-    , SignatureMethod: 'Hmac' + this.algorithm
-    , SignatureVersion: DEFAULT_SIGNATURE_VERSION
-    , Version: DEFAULT_API_VERSION
-    , Expires: this.date
     , Source: this.from
   };
 
@@ -220,18 +145,13 @@ Email.prototype.extractRecipient = function (options, prop) {
 /**
  * Creates required AWS headers.
  *
+ * No additional custom headers by default.
+ * 
  * @return Object
  **/
 Email.prototype.headers = function () {
   var headers = {};
-
-  headers.Date = this.date;
-  headers['X-Amzn-Authorization'] = DEFAULT_AUTH_PATTERN
-    .replace('{key}', this.key)
-    .replace('{algorithm}', 'Hmac' + this.algorithm)
-    .replace('{signature}', this.signature());
-
-	return headers;
+  return headers;
 };
 
 
@@ -242,33 +162,78 @@ Email.prototype.headers = function () {
  * @api Public
  **/
 Email.prototype.send = function send (callback) {
-  var invalid = this.validate();
+	var self = this;
+
+  var invalid = self.validate();
 
   if (invalid) {
     return callback(new Error(invalid));
   }
 
-  return post(this.amazon, this.data(), this.headers(), callback);
-};
+	// Prepare the data and send to it AWS SES REST API
 
+  var data = querystring.stringify(self.data());
+  var parsedUrl = parse(self.amazon);
+  var headers = self.headers();
+
+  headers['Connection'] = 'Keep-Alive';
+
+  var options = {
+      uri: self.amazon
+    , host: parsedUrl.hostname
+    , headers: headers
+    , body: data
+    , service: 'ses'
+  };
+
+	var signedOpts = aws4.sign(options, {
+    accessKeyId : self.key,
+    secretAccessKey : self.secret
+	});
+
+  debug('posting: %j', signedOpts);
+
+  request(signedOpts, function (err, res, data) {
+ 			self._processResponse(err, res, data, callback)
+	});
+
+};
 
 /**
- * Creates the Amazon signature for the request.
+ * Process a response from the 'request' call used to POST email to SES
+ * @private
  *
- * @return base64 encoded string
- **/
-Email.prototype.signature = function () {
-  if (this._signature) {
-    return this._signature;
+ */
+Email.prototype._processResponse = function _processResponse (err, res, data, callback) {
+  debug('received: %s %d %j', err, res && res.statusCode || 0, data);
+
+  if (err) {
+    return callback({
+      Type : "NodeSesInternal",
+      Code : "RequestError",
+      Message: err,
+    }, data, res);
   }
 
-  this._signature = crypto
-    .createHmac(this.algorithm.toLowerCase(), this.secret)
-    .update(this.date)
-    .digest('base64');
+  if (res.statusCode < 200 || res.statusCode >= 400) {
+    return xmlParser.parseString(data,function(err,result){
+        if(err) {
+          return callback({
+            Type: "NodeSesInternal",
+            Code: "ParseError",
+            Message: err
+          });
+        }
 
-  return this._signature;
+        // Return an error object with keys of Type, Code and Message
+        // Rference docs at: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/query-interface-responses.html
+        return callback(result.ErrorResponse.Error);
+    });
+  }
+  return callback(null, data, res);
 };
+
+
 
 
 /**

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -2,9 +2,7 @@
 'use strict';
 
 var email = require('./email')
-
-  , DEFAULT_API_HOST = 'https://email.us-east-1.amazonaws.com'
-  , DEFAULT_SIGNATURE_ALGORITHM = 'SHA1';
+  , DEFAULT_API_HOST = 'https://email.us-east-1.amazonaws.com';
 
 
 /**
@@ -26,8 +24,7 @@ function expect (options, key) {
  *
  *    key - your AWS SES key
  *    secret - your AWS SES secret
- *    algorithm - [optional] the AWS algorithm you are using. defaults to SHA1.
- *    amazon - [optional] the amazon end-point uri. defaults to amazon east.
+ *    amazon - [optional] the amazon end-point uri. defaults to amazon `https://email.us-east-1.amazonaws.com`
  *
  * Example:
  *
@@ -49,8 +46,8 @@ function expect (options, key) {
 function SESClient (options) {
   this.key = expect(options, 'key');
   this.secret = expect(options, 'secret');
-  this.algorithm = options.algorithm || exports.algorithm;
   this.amazon = options.amazon || exports.amazon;
+`https://email.us-east-1.amazonaws.com`
 }
 
 
@@ -63,7 +60,6 @@ function SESClient (options) {
 SESClient.prototype.sendEmail = function (options, callback) {
   options.key = options.key = this.key;
   options.secret = options.secret || this.secret;
-  options.algorithm = options.algorithm || this.algorithm;
   options.amazon = options.amazon || this.amazon;
   options.action = email.actions.SendEmail;
 
@@ -88,7 +84,6 @@ SESClient.prototype.sendemail = SESClient.prototype.sendEmail;
 SESClient.prototype.sendRawEmail = function (options, callback) {
   options.key = options.key || this.key;
   options.secret = options.secret || this.secret;
-  options.algorithm = options.algorithm || this.algorithm;
   options.amazon = options.amazon || this.amazon;
   options.action = email.actions.SendRawEmail;
 
@@ -105,5 +100,4 @@ exports.createClient = function createClient (options) {
 
 exports.Email = email.Email;
 exports.amazon = DEFAULT_API_HOST;
-exports.algorithm = DEFAULT_SIGNATURE_ALGORITHM;
 exports.version = require('../package.json').version;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "make test"
   },
   "dependencies": {
+    "aws4": "^1.4.1",
     "debug": "^2.2.0",
     "request": "^2.70.0",
     "xml2js": "0.4.*"

--- a/test/index.js
+++ b/test/index.js
@@ -385,7 +385,7 @@ describe('sendEmail', function(){
     });
 
     it('should callback an error', function(done){
-      this.timeout(5000);
+      this.timeout(10000);
       var calledTimes = 0;
       email.send(function (err) {
         calledTimes++;
@@ -404,6 +404,7 @@ describe('sendEmail', function(){
             key: process.env.NODE_SES_KEY
           , secret: process.env.NODE_SES_SECRET
         });
+        this.timeout(10000);
 
         client.sendemail({
             from: 'noreply@learnboost.com'
@@ -565,7 +566,7 @@ describe('sendRawEmail', function(){
     });
 
     it('should callback an error', function(done){
-      this.timeout(5000);
+      this.timeout(10000);
       var calledTimes = 0;
       email.send(function (err) {
         calledTimes++;

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,6 @@ function create (){
   return new ses.Email({
       key: 'key'
     , secret: 'secret'
-    , algorithm: 'algo'
     , from: 'from'
     , subject: 'subject'
     , message: 'message'
@@ -27,7 +26,6 @@ function createRaw (){
       action : 'SendRawEmail'
     , key: 'key'
     , secret: 'secret'
-    , algorithm: 'algo'
     , from: 'from'
     , rawMessage: 'rawMessage'
   });
@@ -56,19 +54,6 @@ describe('createClient', function(){
 
   it('should have a secret', function(){
     assert.ok(client.secret);
-  });
-
-  it('should have an algorithm', function(){
-    assert.ok(client.algorithm);
-  });
-
-  it('algorithm should default to SHA1', function(){
-    assert.equal(client.algorithm, 'SHA1');
-  });
-
-  it('algorithm should be overiddable', function(){
-    var client = ses.createClient({ algorithm: 'different', key: 1, secret: 2 });
-    assert.equal(client.algorithm, 'different');
   });
 
   it('should have an amazon property', function(){
@@ -137,10 +122,6 @@ describe('sendEmail', function(){
 
   it('should have secret', function(){
     assert.equal('secret', email.secret);
-  });
-
-  it('should have algorithm', function(){
-    assert.equal('algo', email.algorithm);
   });
 
   it('should have from', function(){
@@ -242,48 +223,6 @@ describe('sendEmail', function(){
     });
   });
 
-  describe('#signature', function(){
-    var email = create();
-    email.algorithm = 'SHA1';
-
-    var sig = crypto
-      .createHmac(email.algorithm.toLowerCase(), email.secret)
-      .update(email.date)
-      .digest('base64');
-
-    it('should be a function', function(){
-      assert.equal('function', typeof email.signature);
-    });
-
-    it('should compute the base64 hmac', function(){
-      assert.equal(sig, email.signature());
-    });
-
-    it('should return the same value if called > 1', function(){
-      assert.equal(sig, email.signature());
-      assert.equal(sig, email.signature());
-      assert.equal(email._signature, email.signature());
-    });
-  });
-
-  describe('#headers', function(){
-    var email = create();
-    email.algorithm = 'SHA1';
-
-    it('should be a function', function(){
-      assert.equal('function', typeof email.headers);
-    });
-
-    it('should add headers', function(){
-      var h = email.headers({});
-      assert(h['X-Amzn-Authorization']);
-      assert(/^AWS3-HTTPS /.test(h['X-Amzn-Authorization']));
-      assert(/AWSAccessKeyId=/.test(h['X-Amzn-Authorization']));
-      assert(/Algorithm=/.test(h['X-Amzn-Authorization']));
-      assert(/Signature=/.test(h['X-Amzn-Authorization']));
-    });
-  });
-
   describe('#validate', function(){
     var email = create();
 
@@ -349,16 +288,6 @@ describe('sendEmail', function(){
       assert.equal(d.Action, 'SendEmail');
       assert(d.AWSAccessKeyId);
       assert.equal(email.key, d.AWSAccessKeyId);
-      assert(d.Signature);
-      assert.equal(email.signature, d.Signature);
-      assert(d.SignatureMethod);
-      assert('Hmac'+email.algorithm, d.SignatureMethod);
-      assert(d.SignatureVersion);
-      assert.equal(2,d.SignatureVersion);
-      assert(d.Version);
-      assert.equal('2010-12-01',d.Version);
-      assert(d.Expires);
-      assert.equal(email.date, d.Expires);
       assert(d.Source);
       assert.equal(email.from, d.Source);
       assert(d['Destination.ToAddresses.member.1']);
@@ -377,7 +306,6 @@ describe('sendEmail', function(){
   describe('#send', function(){
     var email = create();
 
-    email.algorithm = 'SHA1';
     email.amazon = ses.amazon;
 
     it('should be a function', function(){
@@ -385,7 +313,7 @@ describe('sendEmail', function(){
     });
 
     it('should callback an error', function(done){
-      this.timeout(10000);
+      this.timeout(20000);
       var calledTimes = 0;
       email.send(function (err) {
         calledTimes++;
@@ -404,17 +332,17 @@ describe('sendEmail', function(){
             key: process.env.NODE_SES_KEY
           , secret: process.env.NODE_SES_SECRET
         });
-        this.timeout(10000);
+        this.timeout(20000);
 
         client.sendemail({
-            from: 'noreply@learnboost.com'
+            from: 'noreply@rideamigos.com'
           , subject: 'testing node-ses'
           , message: 'this is a test'
           , altText: 'this is an alt txt'
-          , to: 'aaron.heckmann+github@gmail.com'
-          , cc: 'aaron.heckmann+github@gmail.com'
-          , bcc: 'aaron.heckmann+github@gmail.com'
-          , replyTo: 'aaron.heckmann+github@gmail.com'
+          , to: 'mark@rideamigos.com'
+          , cc: 'mark@rideamigos.com'
+          , bcc: 'mark@rideamigos.com'
+          , replyTo: 'mark@rideamigos.com'
         }, function (err, data) {
           assert(!err);
           assert(data);
@@ -438,10 +366,6 @@ describe('sendRawEmail', function(){
     assert.equal('secret', email.secret);
   });
 
-  it('should have algorithm', function(){
-    assert.equal('algo', email.algorithm);
-  });
-
   it('should have from', function(){
     assert.equal('from', email.from);
   });
@@ -450,46 +374,13 @@ describe('sendRawEmail', function(){
     assert.equal('rawMessage', email.rawMessage);
   });
 
-  describe('#signature', function(){
-    var email = createRaw();
-    email.algorithm = 'SHA1';
-
-    var sig = crypto
-      .createHmac(email.algorithm.toLowerCase(), email.secret)
-      .update(email.date)
-      .digest('base64');
-
-    it('should be a function', function(){
-      assert.equal('function', typeof email.signature);
-    });
-
-    it('should compute the base64 hmac', function(){
-      assert.equal(sig, email.signature());
-    });
-
-    it('should return the same value if called > 1', function(){
-      assert.equal(sig, email.signature());
-      assert.equal(sig, email.signature());
-      assert.equal(email._signature, email.signature());
-    });
-  });
-
   describe('#headers', function(){
     var email = createRaw();
-    email.algorithm = 'SHA1';
 
     it('should be a function', function(){
       assert.equal('function', typeof email.headers);
     });
 
-    it('should add headers', function(){
-      var h = email.headers({});
-      assert(h['X-Amzn-Authorization']);
-      assert(/^AWS3-HTTPS /.test(h['X-Amzn-Authorization']));
-      assert(/AWSAccessKeyId=/.test(h['X-Amzn-Authorization']));
-      assert(/Algorithm=/.test(h['X-Amzn-Authorization']));
-      assert(/Signature=/.test(h['X-Amzn-Authorization']));
-    });
   });
 
   describe('#validate', function(){
@@ -539,16 +430,6 @@ describe('sendRawEmail', function(){
       assert.equal(d.Action, 'SendRawEmail');
       assert(d.AWSAccessKeyId);
       assert.equal(email.key, d.AWSAccessKeyId);
-      assert(d.Signature);
-      assert.equal(email.signature, d.Signature);
-      assert(d.SignatureMethod);
-      assert('Hmac'+email.algorithm, d.SignatureMethod);
-      assert(d.SignatureVersion);
-      assert.equal(2,d.SignatureVersion);
-      assert(d.Version);
-      assert.equal('2010-12-01',d.Version);
-      assert(d.Expires);
-      assert.equal(email.date, d.Expires);
       assert(d.Source);
       assert.equal(email.from, d.Source);
       assert(d['RawMessage.Data']);
@@ -558,7 +439,6 @@ describe('sendRawEmail', function(){
   describe('#send', function(){
     var email = createRaw();
 
-    email.algorithm = 'SHA1';
     email.amazon = ses.amazon;
 
     it('should be a function', function(){
@@ -566,7 +446,7 @@ describe('sendRawEmail', function(){
     });
 
     it('should callback an error', function(done){
-      this.timeout(10000);
+      this.timeout(20000);
       var calledTimes = 0;
       email.send(function (err) {
         calledTimes++;
@@ -575,7 +455,7 @@ describe('sendRawEmail', function(){
         assert(err.Message);
         assert(/^The security token included in the request is invalid/.test(err.Message));
         // Wait to see if the code is accidentally going to run the test before declaring done.
-        setTimeout(done,1000);
+        setTimeout(done,2000);
       });
     });
 
@@ -587,10 +467,10 @@ describe('sendRawEmail', function(){
         });
 
         client.sendRawEmail({
-            from: 'noreply@learnboost.com'
+            from: 'noreply@rideamigos.com'
           , rawMessage: [
-              'From: <noreply@learnboost.com>'
-            , 'To: <aaron.heckmann+github@gmail.com>'
+              'From: <noreply@rideamigos.com>'
+            , 'To: <mark@rideamigos.com>'
             , 'Subject: greetings'
             , 'Content-Type: multipart/mixed;'
             , '    boundary="_003_97DCB304C5294779BEBCFC8357FCC4D2"'

--- a/test/index.js
+++ b/test/index.js
@@ -355,6 +355,40 @@ describe('sendEmail', function(){
   });
 });
 
+describe('_processResponse', function () {
+  var email = create();
+
+  it('should errback with error Type:NodeSesInternal error if there is an error with the HTTP response', function(done) {
+      // For now, the 'message' is being returned as object, but #34 is expected to make a string
+      email._processResponse({ message: 'BOOM'}, undefined, undefined, function (error) {
+          assert.deepEqual(error, {
+            Type: 'NodeSesInternal',
+            Code: 'RequestError',
+            Message: {
+              message : 'BOOM'
+            }
+          });
+          done();
+      })
+  });
+
+	// Here we return Error objects in message, but #34 will change this to strings.
+  it('Should errback with Type:NodeSesInternal/Code:ParseError if error response cannot be parsed as XML', function (done) {
+      var res = { statusCode : 500 };
+      var data = 'BOOM';
+      email._processResponse(undefined,  res , data, function (error) {
+          assert.deepEqual(error, {
+            Type: 'NodeSesInternal',
+            Code: 'ParseError',
+            Message: new Error("Non-whitespace before first tag.\nLine: 0\nColumn: 1\nChar: B")
+          });
+          done();
+      })
+
+
+  });
+});
+
 describe('sendRawEmail', function(){
   var email = createRaw();
 

--- a/test/index.js
+++ b/test/index.js
@@ -326,7 +326,7 @@ describe('sendEmail', function(){
       });
     });
 
-    if (process.env.NODE_SES_KEY && process.env.NODE_SES_SECRET) {
+    if (process.env.NODE_SES_KEY && process.env.NODE_SES_SECRET && process.env.NODE_SES_EMAIL) {
       it('should succeed', function(done){
         var client = ses.createClient({
             key: process.env.NODE_SES_KEY
@@ -335,14 +335,14 @@ describe('sendEmail', function(){
         this.timeout(20000);
 
         client.sendemail({
-            from: 'noreply@rideamigos.com'
+            from: process.env.NODE_SES_EMAIL
           , subject: 'testing node-ses'
           , message: 'this is a test'
           , altText: 'this is an alt txt'
-          , to: 'mark@rideamigos.com'
-          , cc: 'mark@rideamigos.com'
-          , bcc: 'mark@rideamigos.com'
-          , replyTo: 'mark@rideamigos.com'
+          , to: process.env.NODE_SES_EMAIL
+          , cc: process.env.NODE_SES_EMAIL
+          , bcc: process.env.NODE_SES_EMAIL
+          , replyTo: process.env.NODE_SES_EMAIL
         }, function (err, data) {
           assert(!err);
           assert(data);
@@ -467,10 +467,10 @@ describe('sendRawEmail', function(){
         });
 
         client.sendRawEmail({
-            from: 'noreply@rideamigos.com'
-          , rawMessage: [
-              'From: <noreply@rideamigos.com>'
-            , 'To: <mark@rideamigos.com>'
+            from: process.env.NODE_SES_EMAIL
+            , rawMessage: [
+              'From: <'+process.env.NODE_SES_EMAIL+'>'
+            , 'To: <'+process.env.NODE_SES_EMAIL+'>'
             , 'Subject: greetings'
             , 'Content-Type: multipart/mixed;'
             , '    boundary="_003_97DCB304C5294779BEBCFC8357FCC4D2"'


### PR DESCRIPTION
As part of this, the ability to change the algorithm is removed. It seemed to be a rarely used feature,
and with version 4, I found no other alternative algorithms documented.

The heavy lifting was outsourced to the 'aws4' module, which allowed for
significant simplications to the internals of mail sending.

The old internal `post` function become much smaller and got folded into
to the `send` function, which did littl except call `post`.

On the other hand, the function to process the response from AWS has
grown in size and complexity was over time, and was extracted into it's
own function, which will make it easier to add unit tests for override
our logic for handing the AWS response.

All regression tests pass, although some related to "algorithm" or
rolling-our-own request signatures were removed.

Would fix #33 and make it easier to unit test #34 