### PR TITLE
Support for json type results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Optional properties (overrides the values set in `createClient`):
 
 The `sendEmail` method transports your message to the AWS SES service. If Amazon
 returns an HTTP status code that's less than `200` or greater than or equal to
-400, we will callback with an `err` object that is directly the _Error_ element of aws error response.
+400, we will callback with an `err` object that is direct presentation of the _Error_ element of aws error response.
 
 See [Error Handling](#error-handling) section below for details on the structure of returned errors.
 
@@ -140,7 +140,7 @@ Within the raw text of the message, the following must be observed:
 
 The `sendRawEmail` method transports your message to the AWS SES service. If Amazon
 returns an HTTP status code that's less than `200` or greater than or equal to
-400, we will callback with an `err` object that is directly the _Error_ element of aws error response.
+400, we will callback with an `err` object that is direct presentation of the _Error_ element of aws error response.
 
 See [Error Handling](#error-handling) section below for details on the structure of returned errors.
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -5,8 +5,6 @@ var aws4 = require('aws4')
   , parse = require('url').parse
   , querystring = require('querystring')
   , request = require('request')
-  , xml2js = require('xml2js')
-  , xmlParser = new xml2js.Parser({explicitArray:false,mergeAttrs:true})
   , SEND_EMAIL_ACTION = 'SendEmail'
   , SEND_RAW_EMAIL_ACTION = 'SendRawEmail';
 
@@ -21,7 +19,6 @@ function Email (options) {
   this.key = options.key;
   this.secret = options.secret;
   this.amazon = options.amazon;
-  this.resultType = options.resultType || 'xml';
   this.from = options.from;
   this.subject = options.subject;
   this.message = options.message;
@@ -152,52 +149,6 @@ Email.prototype.headers = function () {
   return headers;
 };
 
-var resultTypes = {
-  json: {
-    mime: 'application/json',
-    toJson: function(data, callback) {
-      if(data && data.Error) {
-        return callback(data.Error);
-      } else {
-        // Cover the same unlikely scenario as with xml response below
-        return callback({
-          Type : "NodeSesInternal",
-          Code : "JsonError",
-          Message: new Error("Malformed error response from aws: " + data)
-        });
-      }
-    }
-  },
-  xml: {
-    mime: 'application/xml',
-    toJson: function(data, callback) {
-      return xmlParser.parseString(data, function(err,result) {
-        if(err) {
-          return callback({
-            Type: "NodeSesInternal",
-            Code: "ParseError",
-            Message: err
-          });
-        }
-        // Return an error object with keys of Type, Code and Message
-        // Reference docs at: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/query-interface-responses.html
-        if(result && result.ErrorResponse){
-          return callback(result.ErrorResponse.Error);
-        }
-        // Once during an S3 outage AWS returned valid XML that didn't match the usual error structure.
-        // We cover this unlikely case
-        else {
-          return callback({
-            Type : "NodeSesInternal",
-            Code : "XmlError",
-            Message: result,
-          })
-        }
-      });
-    }
-  }
-};
-
 /**
  * Sends the email.
  *
@@ -220,7 +171,6 @@ Email.prototype.send = function send (callback) {
   var headers = self.headers();
 
   headers['Connection'] = 'Keep-Alive';
-  headers['Accept'] = resultTypes[self.resultType].mime;
 
   var options = {
       uri: self.amazon
@@ -228,7 +178,7 @@ Email.prototype.send = function send (callback) {
     , headers: headers
     , body: data
     , service: 'ses'
-    , json: self.resultType === 'json'
+    , json: true
   };
 
 	var signedOpts = aws4.sign(options, {
@@ -260,7 +210,17 @@ Email.prototype._processResponse = function _processResponse (err, res, data, ca
   }
 
   if (res.statusCode < 200 || res.statusCode >= 400) {
-    return resultTypes[this.resultType].toJson(data, callback);
+    if(data && data.Error) {
+      return callback(data.Error);
+    } else {
+      // Once during an S3 outage AWS error responses had invalid schema.
+      // Cover the unlikely scenario, that error json response has wrong structure by this custom error.
+      return callback({
+        Type : "NodeSesInternal",
+        Code : "JsonError",
+        Message: new Error("Malformed error response from aws: " + data)
+      });
+    }
   } else {
     return callback(null, data, res);
   }
@@ -291,10 +251,6 @@ Email.prototype.validate = function () {
   // all actions require the following
   if (!(this.from && this.from.length)) {
     return 'From is required';
-  }
-
-  if (!resultTypes[this.resultType]) {
-    return "Invalid resultType '" + this.resultType + "'. Valid values are: " + Object.keys(resultTypes).join(',');
   }
 };
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -7,11 +7,8 @@ var aws4 = require('aws4')
   , request = require('request')
   , xml2js = require('xml2js')
   , xmlParser = new xml2js.Parser({explicitArray:false,mergeAttrs:true})
-
   , SEND_EMAIL_ACTION = 'SendEmail'
   , SEND_RAW_EMAIL_ACTION = 'SendRawEmail';
-
-
 
 
 /**
@@ -24,6 +21,7 @@ function Email (options) {
   this.key = options.key;
   this.secret = options.secret;
   this.amazon = options.amazon;
+  this.resultType = options.resultType || 'xml';
   this.from = options.from;
   this.subject = options.subject;
   this.message = options.message;
@@ -146,7 +144,7 @@ Email.prototype.extractRecipient = function (options, prop) {
  * Creates required AWS headers.
  *
  * No additional custom headers by default.
- * 
+ *
  * @return Object
  **/
 Email.prototype.headers = function () {
@@ -154,6 +152,51 @@ Email.prototype.headers = function () {
   return headers;
 };
 
+var resultTypes = {
+  json: {
+    mime: 'application/json',
+    toJson: function(data, callback) {
+      if(data && data.Error) {
+        return callback(data.Error);
+      } else {
+        // Cover the same unlikely scenario as with xml response below
+        return callback({
+          Type : "NodeSesInternal",
+          Code : "JsonError",
+          Message: new Error("Malformed error response from aws: " + data)
+        });
+      }
+    }
+  },
+  xml: {
+    mime: 'application/xml',
+    toJson: function(data, callback) {
+      return xmlParser.parseString(data, function(err,result) {
+        if(err) {
+          return callback({
+            Type: "NodeSesInternal",
+            Code: "ParseError",
+            Message: err
+          });
+        }
+        // Return an error object with keys of Type, Code and Message
+        // Reference docs at: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/query-interface-responses.html
+        if(result && result.ErrorResponse){
+          return callback(result.ErrorResponse.Error);
+        }
+        // Once during an S3 outage AWS returned valid XML that didn't match the usual error structure.
+        // We cover this unlikely case
+        else {
+          return callback({
+            Type : "NodeSesInternal",
+            Code : "XmlError",
+            Message: result,
+          })
+        }
+      });
+    }
+  }
+};
 
 /**
  * Sends the email.
@@ -177,6 +220,7 @@ Email.prototype.send = function send (callback) {
   var headers = self.headers();
 
   headers['Connection'] = 'Keep-Alive';
+  headers['Accept'] = resultTypes[self.resultType].mime;
 
   var options = {
       uri: self.amazon
@@ -184,6 +228,7 @@ Email.prototype.send = function send (callback) {
     , headers: headers
     , body: data
     , service: 'ses'
+    , json: self.resultType === 'json'
   };
 
 	var signedOpts = aws4.sign(options, {
@@ -196,7 +241,6 @@ Email.prototype.send = function send (callback) {
   request(signedOpts, function (err, res, data) {
  			self._processResponse(err, res, data, callback)
 	});
-
 };
 
 /**
@@ -216,37 +260,11 @@ Email.prototype._processResponse = function _processResponse (err, res, data, ca
   }
 
   if (res.statusCode < 200 || res.statusCode >= 400) {
-    return xmlParser.parseString(data,function(err,result){
-        if(err) {
-          return callback({
-            Type: "NodeSesInternal",
-            Code: "ParseError",
-            Message: err
-          });
-        }
-
-        // Return an error object with keys of Type, Code and Message
-        // Reference docs at: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/query-interface-responses.html
-        if(result && result.ErrorResponse){
-          return callback(result.ErrorResponse.Error)
-        }
-        // Once during an S3 outage AWS returned valid XML that didn't match the usual error structure.
-        // We cover this unlikely case
-        else {
-          return callback({
-            Type : "NodeSesInternal",
-            Code : "XmlError",
-            Message: result,
-          })
-        }
-
-    });
+    return resultTypes[this.resultType].toJson(data, callback);
+  } else {
+    return callback(null, data, res);
   }
-  return callback(null, data, res);
 };
-
-
-
 
 /**
  * Validates the input.
@@ -273,6 +291,10 @@ Email.prototype.validate = function () {
   // all actions require the following
   if (!(this.from && this.from.length)) {
     return 'From is required';
+  }
+
+  if (!resultTypes[this.resultType]) {
+    return "Invalid resultType '" + this.resultType + "'. Valid values are: " + Object.keys(resultTypes).join(',');
   }
 };
 

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -47,6 +47,7 @@ function SESClient (options) {
   this.key = expect(options, 'key');
   this.secret = expect(options, 'secret');
   this.amazon = options.amazon || exports.amazon;
+  this.resultType = options.resultType || 'xml';
 }
 
 
@@ -60,6 +61,7 @@ SESClient.prototype.sendEmail = function (options, callback) {
   options.key = options.key = this.key;
   options.secret = options.secret || this.secret;
   options.amazon = options.amazon || this.amazon;
+  options.resultType = options.resultType || this.resultType;
   options.action = email.actions.SendEmail;
 
   var message = new email.Email(options);
@@ -84,6 +86,7 @@ SESClient.prototype.sendRawEmail = function (options, callback) {
   options.key = options.key || this.key;
   options.secret = options.secret || this.secret;
   options.amazon = options.amazon || this.amazon;
+  options.resultType = options.resultType || this.resultType;
   options.action = email.actions.SendRawEmail;
 
   var message = new email.Email(options);

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -47,7 +47,6 @@ function SESClient (options) {
   this.key = expect(options, 'key');
   this.secret = expect(options, 'secret');
   this.amazon = options.amazon || exports.amazon;
-  this.resultType = options.resultType || 'xml';
 }
 
 
@@ -61,7 +60,6 @@ SESClient.prototype.sendEmail = function (options, callback) {
   options.key = options.key = this.key;
   options.secret = options.secret || this.secret;
   options.amazon = options.amazon || this.amazon;
-  options.resultType = options.resultType || this.resultType;
   options.action = email.actions.SendEmail;
 
   var message = new email.Email(options);
@@ -86,7 +84,6 @@ SESClient.prototype.sendRawEmail = function (options, callback) {
   options.key = options.key || this.key;
   options.secret = options.secret || this.secret;
   options.amazon = options.amazon || this.amazon;
-  options.resultType = options.resultType || this.resultType;
   options.action = email.actions.SendRawEmail;
 
   var message = new email.Email(options);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "aws4": "^1.4.1",
     "debug": "^2.2.0",
-    "request": "^2.70.0",
-    "xml2js": "0.4.*"
+    "request": "^2.70.0"
   },
   "devDependencies": {
     "jshint": "^2.8.0",


### PR DESCRIPTION
AWS API and request library have both good support for json format, so it would be possible just use those without any xml parsing needed.

Left the xml as default type so that the change is fully backwards compatible. All functionality is exactly the same as before unless if you specify the `resultType: 'json'` option which will then just use the request library's `json: true` mode and consequently ask AWS to return result as json format. request will also automatically parse the json to object before callbacking.

Since JavaScript users might prefer JSON over XML, maybe it could be considered also later on to switch `json`resultType to be default when releasing version 3 and backwards compatibility can be broken. Would still keep the XML option also.
