### PR TITLE
Load key and secret from environment if not provided

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -186,10 +186,11 @@ Email.prototype.send = function send (callback) {
     , service: 'ses'
   };
 
-	var signedOpts = aws4.sign(options, {
+  var credentials = self.key && self.secret && {
     accessKeyId : self.key,
     secretAccessKey : self.secret
-	});
+  };
+  var signedOpts = aws4.sign(options, credentials);
 
   debug('posting: %j', signedOpts);
 

--- a/lib/ses.js
+++ b/lib/ses.js
@@ -6,18 +6,6 @@ var email = require('./email')
 
 
 /**
- * Options helper.
- * @private
- */
-function expect (options, key) {
-  if (options && options[key]) {
-    return options[key];
-  }
-
-  throw new Error(key + ' is required');
-}
-
-/**
  * SESClient
  *
  * `options` is an object with these properties:
@@ -44,8 +32,9 @@ function expect (options, key) {
  * @param {Object} options
  */
 function SESClient (options) {
-  this.key = expect(options, 'key');
-  this.secret = expect(options, 'secret');
+  options = options || {};
+  this.key = options.key;
+  this.secret = options.secret;
   this.amazon = options.amazon || exports.amazon;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,24 +74,9 @@ describe('createClient', function(){
     assert.equal(client.amazon, 'http://www.google.com');
   });
 
-  it('should require a key', function(){
-    try {
-      ses.createClient();
-    } catch (err) {
-      if (!/key is required/.test(err)) {
-        throw err;
-      }
-    }
-  });
-
-  it('should require a secret', function(){
-    try {
-      ses.createClient({ key: 1 });
-    } catch (err) {
-      if (!/secret is required/.test(err)) {
-        throw err;
-      }
-    }
+  it('should not require options', function(){
+    var client = ses.createClient();
+    assert.equal(client.key, undefined);
   });
 
   describe('sendemail', function(){


### PR DESCRIPTION
- Remove check for compulsory options.
- `aws4` automatically falls back to reading `key`, `secret` and `session` from the environment.

Closes #48 