### PR TITLE
Make work with non-default region

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -2,7 +2,6 @@
 
 var aws4 = require('aws4')
   , debug = require('debug')('node-ses')
-  , parse = require('url').parse
   , querystring = require('querystring')
   , request = require('request')
   , xml2js = require('xml2js')
@@ -196,14 +195,12 @@ Email.prototype.send = function send (callback) {
 	// Prepare the data and send to it AWS SES REST API
 
   var data = querystring.stringify(self.data());
-  var parsedUrl = parse(self.amazon);
   var headers = self.headers();
 
   headers['Connection'] = 'Keep-Alive';
 
   var options = {
       uri: self.amazon
-    , host: parsedUrl.hostname
     , headers: headers
     , body: data
     , service: 'ses'


### PR DESCRIPTION
When passing the `host` option to `aws4.sign()` with a non default region (e.g. 'eu-central-1') then this will result in a `SignatureDoesNotMatch` error message.

To fix this, this PR removes the `host` option, which is constructed by `aws4` anyways.