### PR TITLE
Make work with eu-central-1 region

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -199,8 +199,6 @@ Email.prototype.send = function send (callback) {
   var parsedUrl = parse(self.amazon);
   var headers = self.headers();
 
-  headers['Connection'] = 'Keep-Alive';
-
   var options = {
       uri: self.amazon
     , host: parsedUrl.hostname
@@ -214,6 +212,8 @@ Email.prototype.send = function send (callback) {
     secretAccessKey : self.secret
   };
   var signedOpts = aws4.sign(options, credentials);
+
+  signedOpts.headers['Connection'] = 'keep-alive';
 
   debug('posting: %j', signedOpts);
 


### PR DESCRIPTION
This is really weird, but when using the `eu-central-1` region the `Connection` header is not allowed to be present before signing, otherwise the request results in a `SignatureDoesNotMatch` error.

Thanks for @mhart for troubleshooting 👍 