### PR TITLE
Connection header dropped since it is not allowed by SIGv4 anymore

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -207,8 +207,6 @@ Email.prototype.send = function send (callback) {
   };
   var signedOpts = aws4.sign(options, credentials);
 
-  signedOpts.headers['Connection'] = 'keep-alive';
-
   debug('posting: %j', signedOpts);
 
   request(signedOpts, (err, res, data) => this._processResponse(err, res, data, callback));


### PR DESCRIPTION
Received the following from AWS which caused me to create this PR:

"SES is working on an infrastructure upgrade with improved security controls. As part of this improvement, we monitored SIGv4 requests and determined that our Simple Email Service endpoints are currently receiving SIGv4 requests using the Connection header from your AWS account. Please note that SIGv4 signed requests using this header will start to fail progressively after 10/29 and you will be required to remove this header from signed headers."