### PR TITLE
Add timeout to client.sendEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ client.sendEmail({
  , subject: 'greetings'
  , message: 'your <b>message</b> goes here'
  , altText: 'plain text'
+ , timeout: 300
 }, function (err, data, res) {
  // ...
 });
@@ -79,16 +80,17 @@ There are several important points to know about SendEmail:
 
 `sendEmail` receives an options object with the following properties:
 
-    `from` - email address from which to send (required)
-    `subject` - string (required). Must be encoded as UTF-8
+    `from` - email address from which to send (required).
+    `subject` - string (required). Must be encoded as UTF-8.
     `message` - can be html (required). Must be encoded as UTF-8.
     `altText` - plain text version of message. Must be encoded as UTF-8.
-    `to` - email address or array of addresses
-    `cc` - email address or array of addresses
-    `bcc` - email address or array of addresses
-    `replyTo` - email address
-    `configurationSet` - SES configuration set name
+    `to` - email address or array of addresses.
+    `cc` - email address or array of addresses.
+    `bcc` - email address or array of addresses.
+    `replyTo` - email address.
+    `configurationSet` - SES configuration set name.
     `messageTags` - SES message tags: array of name/value objects, e.g. { name: xid, value: 1 }
+    `timeout` - boolean, set the timeout for the HTTP request.
 
 At least one of `to`, `cc` or `bcc` is required.
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -199,6 +199,7 @@ Email.prototype.send = function send (callback) {
     , headers: headers
     , body: data
     , service: 'ses'
+    , timeout: 3000
   };
 
   var credentials = this.key && this.secret && {

--- a/lib/email.js
+++ b/lib/email.js
@@ -28,6 +28,7 @@ function Email (options) {
   this.rawMessage = options.rawMessage;
   this.configurationSet = options.configurationSet;
   this.messageTags = options.messageTags;
+  this.timeout = options.timeout;
   this.extractRecipient(options, 'to');
   this.extractRecipient(options, 'cc');
   this.extractRecipient(options, 'bcc');
@@ -192,14 +193,13 @@ Email.prototype.send = function send (callback) {
   var data = querystring.stringify(this.data());
   var parsedUrl = parse(this.amazon);
   var headers = this.headers();
-
   var options = {
       uri: this.amazon
     , host: parsedUrl.hostname
     , headers: headers
     , body: data
     , service: 'ses'
-    , timeout: 3000
+    , timeout: this.timeout || 300
   };
 
   var credentials = this.key && this.secret && {


### PR DESCRIPTION
The default nodejs request timeout is quite large (120000ms), adding option to specify your own timeout, alleviates waiting, when doing tests when simulating spotty network environments. 

Feel free to adjust the default 300ms timeout.