### PR TITLE
ClientConfig interface created

### DIFF
--- a/node-ses.d.ts
+++ b/node-ses.d.ts
@@ -54,13 +54,10 @@ declare module "node-ses" {
     sendemail(options: sendEmailOptions, callback: Callback): void;
     sendRawEmail(options: sendRawEmailOptions, callback: Callback): void;
   }
-  export function createClient({
-    key,
-    secret,
-    amazon
-  }: {
+  export interface ClientConfig {
     key: string;
     secret: string;
     amazon?: string;
-  }): Client;
+  }
+  export function createClient(options?: ClientConfig): Client;
 }


### PR DESCRIPTION
I made an interface for createClient function in node-ses.d.ts. 

Previously, key and secret were made required inputs and, hence, users had to add an empty object as below in order to instantiate client and let it look for environmental variables:

`private readonly client = ses.createClient({} as any);`

With this change, users can just do so without the empty object. 

`private readonly client = ses.createClient();`


Seeing the "sendEmailOptions" interface, the package owners intention was supposedly to keep the package key and secret optional and let the package fetch from environmental variables. I hope this change is aligned with owners' intention.

Here is the actual changes I made:
`  export interface ClientConfig {
    key: string;
    secret: string;
    amazon?: string;
  }
  export function createClient(options?: ClientConfig): Client;`